### PR TITLE
Add necessary YAML files to deploy job-pod-reaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,62 @@ Current list of resources that can be reaped:
 * ConfigMap
 * Secret
 
+## Install
+
+First install the necessary Namespace and RBAC resources:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/OSC/job-pod-reaper/main/install/namespace-rbac.yaml
+```
+
+For Open OnDemand a deployment can be installed using Open OnDemand specific deployment:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/OSC/job-pod-reaper/main/install/ondemand-deployment.yaml
+```
+
+A more generic deployment:
+
+```
+kubectl apply -f https://raw.githubusercontent.com/OSC/job-pod-reaper/main/install/deployment.yaml
+```
+
+If you wish to authorize the job-pod-reaper to reap only specific namespaces, those namespaces will need to have the following RoleBinding added (replace `$NAMESPACE` with namespace name).
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: $NAMESPACE-job-pod-reaper-rolebinding
+  namespace: $NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: job-pod-reaper
+subjects:
+- kind: ServiceAccount
+  name: job-pod-reaper
+  namespace: job-pod-reaper
+```
+
+If you wish to authorize job-pod-reader for all namespaces:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: job-pod-reaper
+  namespace: job-pod-reaper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: job-pod-reaper
+subjects:
+- kind: ServiceAccount
+  name: job-pod-reaper
+  namespace: job-pod-reaper
+```
+
 ## Configuration
 
 To give a lifetime to your pods, add the following annotation:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Current list of resources that can be reaped:
 * ConfigMap
 * Secret
 
+## Kubernetes support
+
+Currently this code is built and tested against Kubernetes 1.19.
+
 ## Install
 
 First install the necessary Namespace and RBAC resources:
@@ -38,7 +42,7 @@ A more generic deployment:
 kubectl apply -f https://raw.githubusercontent.com/OSC/job-pod-reaper/main/install/deployment.yaml
 ```
 
-If you wish to authorize the job-pod-reaper to reap only specific namespaces, those namespaces will need to have the following RoleBinding added (replace `$NAMESPACE` with namespace name).
+If you wish to authorize the job-pod-reaper to reap only specific namespaces, those namespaces will need to have the following RoleBinding added (replace `$NAMESPACE` with namespace name). Use this `RoleBinding` on namespaces listed with `--reap-namespaces` or if those namespaces match labels defined with `--namespace-labels`
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -56,7 +60,7 @@ subjects:
   namespace: job-pod-reaper
 ```
 
-If you wish to authorize job-pod-reader for all namespaces:
+If you wish to authorize job-pod-reader for all namespaces the following `ClusterRoleBinding` is required.  This would be needed if `--namespace-labels` is not defined and you set `--reap-namespaces=ALL`.
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/deployment.yaml
+++ b/install/deployment.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: job-pod-reaper
+  namespace: job-pod-reaper
+spec:
+  selector:
+    matchLabels:
+      app: job-pod-reaper
+  template:
+    metadata:
+      labels:
+        app: job-pod-reaper
+    spec:
+      serviceAccountName: job-pod-reaper
+      containers:
+      - name: job-pod-reaper
+        image: docker.io/ohiosupercomputer/job-pod-reaper:v0.1.0
+        imagePullPolicy: Always
+        args:
+        - --reap-max=30
+        - --reap-evicted-pods
+        - --reap-interval=60s
+        - --reap-namespaces=all
+        - --job-label=job
+        - --log.level=debug
+        - --log.format=logfmt
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/install/namespace-rbac.yaml
+++ b/install/namespace-rbac.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: job-pod-reaper
+  labels:
+    name: job-pod-reaper
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: job-pod-reaper
+  namespace: job-pod-reaper
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: job-pod-reaper
+  namespace: job-pod-reaper
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - configmaps
+  - secrets
+  verbs:
+  - list
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: job-pod-reaper-list-namespaces
+  namespace: job-pod-reaper
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: job-pod-reaper-list-namespaces
+  namespace: job-pod-reaper
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: job-pod-reaper-list-namespaces
+subjects:
+- kind: ServiceAccount
+  name: job-pod-reaper
+  namespace: job-pod-reaper

--- a/install/ondemand-deployment.yaml
+++ b/install/ondemand-deployment.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ondemand-job-pod-reaper
+  namespace: job-pod-reaper
+spec:
+  selector:
+    matchLabels:
+      app: ondemand-job-pod-reaper
+  template:
+    metadata:
+      labels:
+        app: ondemand-job-pod-reaper
+    spec:
+      serviceAccountName: job-pod-reaper
+      containers:
+      - name: ondemand-job-pod-reaper
+        image: docker.io/ohiosupercomputer/job-pod-reaper:v0.1.0
+        imagePullPolicy: Always
+        args:
+        - --reap-max=30
+        - --reap-evicted-pods
+        - --reap-interval=60s
+        - --namespace-labels=app.kubernetes.io/name=open-ondemand
+        - --pods-labels=app.kubernetes.io/managed-by=open-ondemand
+        - --job-label=job
+        - --log.level=debug
+        - --log.format=logfmt
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      nodeSelector:
+        kubernetes.io/os: linux


### PR DESCRIPTION
@johrstrom For OnDemand we would add something like this to bootstrap:

```yaml
---
# allow job-pod-reaper to see this namespace
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: "$ONDEMAND_USERNAME-job-pod-reaper-rolebinding"
  namespace: "$NAMESPACE"
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: job-pod-reaper
subjects:
- kind: ServiceAccount
  name: job-pod-reaper
  namespace: job-pod-reaper
```